### PR TITLE
fix indicator name

### DIFF
--- a/src/rma.ts
+++ b/src/rma.ts
@@ -1,8 +1,8 @@
 import { SMA } from './sma';
 
 /**
- * The RMA (Relative Moving Average) is a powerful indicator based on the Simple Moving Average indicator.
- * The Simple Moving Average (SMA) indicator is useful to identify the start and rreversal of a trend.
+ * The RMA (Wilder's Smoothed Moving Average) is a powerful indicator based on the Simple Moving Average indicator.
+ * The Simple Moving Average (SMA) indicator is useful to identify the start and reversal of a trend.
  */
 export class RMA {
     private smooth: number;


### PR DESCRIPTION
I checked the output values of your RMA implementation and they correlate with the values listed here:
- https://runkit.com/anandaravindan/wema
- https://tulipindicators.org/wilders

From your implementation (i.e. `this.smooth = 1 / this.period`) you seem to have implemented [Wilder's Smoothing](https://tlc.thinkorswim.com/center/reference/Tech-Indicators/studies-library/V-Z/WildersSmoothing) which is not a [Relative Moving Average (RMA)](https://www.youtube.com/watch?v=76P-2e8gn4g).