### PR TITLE
fixed atr

### DIFF
--- a/src/atr.ts
+++ b/src/atr.ts
@@ -42,11 +42,19 @@ export class ATR {
 
         this.prevClose = close;
 
+        if(!trueRange) {
+            return;
+        }
+
         return this.avg.nextValue(trueRange);
     }
 
     momentValue(high: number, low: number) {
         const trueRange = this.getTrueRange(high, low);
+
+        if(!trueRange) {
+            return;
+        }
 
         return this.avg.momentValue(trueRange);
     }
@@ -56,7 +64,7 @@ export class ATR {
             return Math.max(high - low, Math.abs(high - this.prevClose), Math.abs(low - this.prevClose));
         }
 
-        return high - low;
+        return null;
     }
 }
 

--- a/tests/atr/atr.spec.ts
+++ b/tests/atr/atr.spec.ts
@@ -17,20 +17,19 @@ describe('ATR', () => {
         });
     });
 
-    it.skip('Cross sdk validate', () => {
+    it('Cross sdk validate', () => {
         const period = 14;
-        const atr = new ATR(period, 'SMMA');
+        const atr = new ATR(period);
         const atr2 = new ATR2({ period, high: [], low: [], close: [] });
 
-        ohlc.forEach((tick, idx) => {
-            const local = atr.nextValue(tick.h, tick.l, tick.c);
-            const cross = atr2.nextValue({ high: tick.h, low: tick.l, close: tick.c });
+        const local = []
+        const cross = []
 
-            // FIX: cross === undefioned at 14 pos, local is fine?
-            if (idx > period) {
-                // console.log(local, cross);
-                expect(local).toEqual(cross);
-            }
+        ohlc.forEach((tick) => {
+            local.push(atr.nextValue(tick.h, tick.l, tick.c));
+            cross.push(atr2.nextValue({ high: tick.h, low: tick.l, close: tick.c }));
         });
+
+        expect(local).toEqual(cross)
     });
 });


### PR DESCRIPTION
The problem was that in test we used SMMA when technical indicators uses WEMA,
True range should return undefined if there's no previous value, so as ATR if true range is undefined,
source code from technical indicators

![image](https://user-images.githubusercontent.com/58230797/144710061-f3b54ff8-3f4d-482e-a023-427e45135fa5.png)
![image](https://user-images.githubusercontent.com/58230797/144710139-399770d5-13c8-47ed-a289-b62e1ecb2347.png)
